### PR TITLE
Update HowTo_ChangePitchAndVolume.md and subproject commit in MonoGame

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ With your environment setup properly, the following explains how to build from s
     git clone https://github.com/MonoGame/monogame.github.io.git
     ```
 
-2. Install npm dependencies
+2. Install DotNet dependencies
 
     ```sh
-    npm install
+    dotnet tool restore
     ```
 
 3. Optional Steps
@@ -29,9 +29,12 @@ With your environment setup properly, the following explains how to build from s
 
    `git submodule update --init --recursive`
 
-4. Run a local build and serve it with hot reloading.  The site is full DocFX now so a single build command will do:
+4. Run a local build and serve it. The site is full DocFX now so a single build command will do:
 
   `dotnet docfx docfx.json --serve`
+
+> [!NOTE]
+> Docfx hosting does not support hot reload, so to refresh the hosted site you will need to stop the agent (ctrl-c) and run the above command again to refresh pages
 
 ## Document styling
 
@@ -52,6 +55,9 @@ The use of DocFX with the updated MonoGame docs site has afforded the use of som
   [DocFX Markdown style guide](https://dotnet.github.io/docfx/docs/markdown.html?tabs=linux%2Cdotnet#alerts)
 
 As an example of a document written using the above notes, please refer to the [HowTo: Create a Render Target tutorial](https://github.com/MonoGame/docs.monogame.github.io/blob/feature/docsmigration/articles/monogame/howto/graphics/HowTo_Create_a_RenderTarget.md)
+
+> [!TIP]
+> No additional text is needed at the bottom of document pages as the licenses and requirements are automatically added by the DocFX build system
 
 ## LICENSE
 

--- a/articles/monogame/howto/audio/HowTo_ChangePitchAndVolume.md
+++ b/articles/monogame/howto/audio/HowTo_ChangePitchAndVolume.md
@@ -52,7 +52,7 @@ The **[SoundEffect.Play](xref:Microsoft.Xna.Framework.Audio.SoundEffect.Play)** 
  > [!NOTE]
  > An instance will play once, to loop the sound, you can use the **[SoundEffectInstance.IsLooped](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.IsLooped)** property to set the sound to loop. Also note that the sound will not repeat until the sound has finished playing. You can utilise the **[SoundEffectInstance.State](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.State)** property to check if the sound is playing, paused or stopped. Use the **[SoundEffectInstance.Stop](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.Stop)** method to stop the sound.
 
- ## An extended example
+ ## An Extended Example
 
  5. Below the **[Game.Draw](xref:Microsoft.Xna.Framework.Game.Draw)** method, create a new method called **IsKeyPressed**, which will check if a specified key is pressed and return a boolean value of true if it has been pressed.
 

--- a/articles/monogame/howto/audio/HowTo_ChangePitchAndVolume.md
+++ b/articles/monogame/howto/audio/HowTo_ChangePitchAndVolume.md
@@ -5,20 +5,39 @@ description: Demonstrates how to manipulate the pitch and volume of sound effect
 
 # Adjusting Pitch and Volume
 
-The [SoundEffect.Play](xref:Microsoft.Xna.Framework.Audio.SoundEffect.Play) method allows you to specify the pitch and volume of a sound to play. However, after you call [Play](xref:Microsoft.Xna.Framework.Audio.SoundEffect.Play), you cannot modify the sound. Using [SoundEffectInstance](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance) for a given [SoundEffect](xref:Microsoft.Xna.Framework.Audio.SoundEffect) allows you to change the pitch and volume of a sound at any time during playback.
+The **[SoundEffect.Play](xref:Microsoft.Xna.Framework.Audio.SoundEffect.Play)** method allows you to specify the pitch and volume of a sound to play. However, after you call **[Play](xref:Microsoft.Xna.Framework.Audio.SoundEffect.Play)**, you cannot modify the sound. Using **[SoundEffectInstance](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance)** for a given **[SoundEffect](xref:Microsoft.Xna.Framework.Audio.SoundEffect)** allows you to change the **pitch** and **volume** of a sound at any time during playback.
+
+> [!NOTE]
+> The pitch of a sound changes the frequency of the sound, which in turn changes the speed of the sound. The volume of a sound changes the amplitude of the sound, which in turn changes the loudness of the sound.
 
 ## Change Pitch and Volume of Sound
 
-1. Declare [SoundEffect](xref:Microsoft.Xna.Framework.Audio.SoundEffect) and [Stream](http://msdn.microsoft.com/en-us/library/system.io.stream.aspx) by using the method shown in [Playing a Sound](HowTo_PlayASound.md). In addition to the method described in [Playing a Sound](HowTo_PlayASound.md), declare [SoundEffectInstance](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance).
+1. Declare a **[SoundEffect](xref:Microsoft.Xna.Framework.Audio.SoundEffect)** and a [Stream](http://msdn.microsoft.com/en-us/library/system.io.stream.aspx) file by using the method shown in [Playing a Sound](HowTo_PlayASound.md). In addition to the method described in [Playing a Sound](HowTo_PlayASound.md), declare a **[SoundEffectInstance](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance)**, we also add a **Sound Effect** field member. We also create two float fields for **pitch** and **volume** to store the pitch and volume of the sound effect and assign initial values to them.
 
     ```csharp
-    SoundEffectInstance soundInstance;
+    // place these usings at the top of the file
+    using System.IO;
+    using Microsoft.Xna.Framework;
+    using Microsoft.Xna.Framework.Audio;
+    using Microsoft.Xna.Framework.Graphics;
+    using Microsoft.Xna.Framework.Input;
+
+    // place these fields at the top of the class
+    private SoundEffect soundEffect;
+    private SoundEffectInstance soundEffectInstance;
+    private float pitch = 0.75f;
+    private float volume = 0.5f;
     ```
+
+> [!NOTE]
+> Usings are declared at the top of the file to ensure that the necessary namespaces are available to the class. The fields are declared at the top of the class to ensure that they are accessible to all methods in the class.
 
 2. In the [Game.LoadContent](xref:Microsoft.Xna.Framework.Game.LoadContent) method, set the SoundEffectInstance object to the return value of [SoundEffect.CreateInstance](xref:Microsoft.Xna.Framework.Audio.SoundEffect.CreateInstance).
 
+2. In the **[Game.LoadContent](xref:Microsoft.Xna.Framework.Game.LoadContent)** method, set the **SoundEffectInstance** object to the return value of **[SoundEffect.CreateInstance](xref:Microsoft.Xna.Framework.Audio.SoundEffect.CreateInstance)**. We also optionally define a variable **soundFile** to store the location of the sound file being used with the **[TitleContainer.OpenStream](xref:Microsoft.Xna.Framework.TitleContainer.OpenStream)** method, which is accessed with the  **using** keyword, and include a field member variable called **soundEffect**, to hold the stream.
+
     ```csharp
-    soundfile = TitleContainer.OpenStream(@"Content\tx0_fire1.wav");
+    using Stream soundfile = TitleContainer.OpenStream(@"Content\Sound__FileName.wav");
     soundEffect = SoundEffect.FromStream(soundfile);
     soundInstance = soundEffect.CreateInstance();
     ```
@@ -27,18 +46,44 @@ The [SoundEffect.Play](xref:Microsoft.Xna.Framework.Audio.SoundEffect.Play) meth
 
     ```csharp
     // Play Sound
-    soundInstance.Play();
+    soundEffectInstance.Play();
     ```
 
-4. Play the sound using [SoundEffectInstance.Play](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.Play).
+ > [!NOTE]
+ > An instance will play once, to loop the sound, you can use the **[SoundEffectInstance.IsLooped](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.IsLooped)** property to set the sound to loop. Also note that the sound will not repeat until the sound has finished playing. You can utilise the **[SoundEffectInstance.State](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.State)** property to check if the sound is playing, paused or stopped. Use the **[SoundEffectInstance.Stop](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.Stop)** method to stop the sound.
+
+ ## An extended example
+
+ 5. Below the **[Game.Draw](xref:Microsoft.Xna.Framework.Game.Draw)** method, create a new method called **IsKeyPressed**, which will check if a specified key is pressed and return a boolean value of true if it has been pressed.
 
     ```csharp
-    // Pitch takes values from -1 to 1
-    soundInstance.Pitch = pitch;
-    
-    // Volume only takes values from 0 to 1
-    soundInstance.Volume = volume;
-    ```
+    private bool IsKeyPressed(Keys key)
+    {
+        return Keyboard.GetState().IsKeyDown(key);
+    }
+	```
+
+ 6. In the **[Game.Update](xref:Microsoft.Xna.Framework.Game.Update)** method, check if the **Space** key is pressed and adjust the pitch and volume of the sound effect accordingly. The pitch and volume values are adjusted by +0.1f each time the **Space key** is pressed. The pitch values are clamped to a minimum value of -1.0f and a maximum value of 1.0f, and the volume values are then clamped to a minimum value of 0f and a maximum value of 1.0f. This is done to ensure that the pitch and volume values are within  valid ranges.
+
+	```csharp
+    // Check if the SpaceKey is pressed and play the instance
+    if (IsKeyPressed(Keys.Space))
+        {
+         pitch += 0.1f;
+         volume += 0.1f;
+         pitch = MathHelper.Clamp(pitch, -1.0f, 1.0f);
+         volume = MathHelper.Clamp(volume, 0f, 1.0f);
+         soundEffectInstance.Pitch = pitch;
+         soundEffectInstance.Volume = volume;
+         soundEffectInstance.Play();
+        }
+	```
+
+ > [!NOTE]
+ > The **MathHelper.Clamp** method is used to ensure that the pitch and volume values are within the valid range. The pitch value is clamped between -1 and 1, while the volume value is clamped between 0 and 1.
+
+ > [!NOTE]
+ > The check for the keypress does not prevent the call to the method repeating so any value entered may peak the value in a singe key press. To prevent this, you can add a delay to the key press check, or use a boolean value to check if the key has been pressed and released.
 
 ## Concepts
 
@@ -68,4 +113,4 @@ Provides a single playing, paused, or stopped instance of a [SoundEffect](xref:M
 
 © 2012 Microsoft Corporation. All rights reserved.  
 
-© 2023 The MonoGame Foundation.
+© 2024 The MonoGame Foundation.

--- a/articles/monogame/howto/audio/HowTo_ChangePitchAndVolume.md
+++ b/articles/monogame/howto/audio/HowTo_ChangePitchAndVolume.md
@@ -1,9 +1,8 @@
 ---
 title: How to adjust Pitch and Volume
 description: Demonstrates how to manipulate the pitch and volume of sound effects as they play.
+requireMSLicense: true
 ---
-
-# Adjusting Pitch and Volume
 
 The **[SoundEffect.Play](xref:Microsoft.Xna.Framework.Audio.SoundEffect.Play)** method allows you to specify the pitch and volume of a sound to play. However, after you call **[Play](xref:Microsoft.Xna.Framework.Audio.SoundEffect.Play)**, you cannot modify the sound. Using **[SoundEffectInstance](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance)** for a given **[SoundEffect](xref:Microsoft.Xna.Framework.Audio.SoundEffect)** allows you to change the **pitch** and **volume** of a sound at any time during playback.
 
@@ -12,7 +11,7 @@ The **[SoundEffect.Play](xref:Microsoft.Xna.Framework.Audio.SoundEffect.Play)** 
 
 ## Change Pitch and Volume of Sound
 
-1. Declare a **[SoundEffect](xref:Microsoft.Xna.Framework.Audio.SoundEffect)** and a [Stream](http://msdn.microsoft.com/en-us/library/system.io.stream.aspx) file by using the method shown in [Playing a Sound](HowTo_PlayASound.md). In addition to the method described in [Playing a Sound](HowTo_PlayASound.md), declare a **[SoundEffectInstance](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance)**, we also add a **Sound Effect** field member. We also create two float fields for **pitch** and **volume** to store the pitch and volume of the sound effect and assign initial values to them.
+1. Declare a **[SoundEffect](xref:Microsoft.Xna.Framework.Audio.SoundEffect)** and a [Stream](http://msdn.microsoft.com/en-us/library/system.io.stream.aspx) file by using the method shown in [Playing a Sound](HowTo_PlayASound.md). In addition to the method described in [Playing a Sound](HowTo_PlayASound.md), declare a **[SoundEffectInstance](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance)** and a **Sound Effect** field member. We also create two float fields for **pitch** and **volume** to store the pitch and volume of the sound effect and assign initial values to them.
 
     ```csharp
     // place these usings at the top of the file
@@ -29,12 +28,12 @@ The **[SoundEffect.Play](xref:Microsoft.Xna.Framework.Audio.SoundEffect.Play)** 
     private float volume = 0.5f;
     ```
 
-> [!NOTE]
-> Usings are declared at the top of the file to ensure that the necessary namespaces are available to the class. The fields are declared at the top of the class to ensure that they are accessible to all methods in the class.
+    > [!NOTE]
+    > Usings are declared at the top of the file to ensure that the necessary namespaces are available to the class. The fields are declared at the top of the class to ensure that they are accessible to all methods in the class.
 
-2. In the [Game.LoadContent](xref:Microsoft.Xna.Framework.Game.LoadContent) method, set the SoundEffectInstance object to the return value of [SoundEffect.CreateInstance](xref:Microsoft.Xna.Framework.Audio.SoundEffect.CreateInstance).
+2. In the [Game.LoadContent](xref:Microsoft.Xna.Framework.Game.LoadContent) method, set the **SoundEffectInstance** object to the return value of [SoundEffect.CreateInstance](xref:Microsoft.Xna.Framework.Audio.SoundEffect.CreateInstance).
 
-2. In the **[Game.LoadContent](xref:Microsoft.Xna.Framework.Game.LoadContent)** method, set the **SoundEffectInstance** object to the return value of **[SoundEffect.CreateInstance](xref:Microsoft.Xna.Framework.Audio.SoundEffect.CreateInstance)**. We also optionally define a variable **soundFile** to store the location of the sound file being used with the **[TitleContainer.OpenStream](xref:Microsoft.Xna.Framework.TitleContainer.OpenStream)** method, which is accessed with the  **using** keyword, and include a field member variable called **soundEffect**, to hold the stream.
+3. In the **[Game.LoadContent](xref:Microsoft.Xna.Framework.Game.LoadContent)** method, set the **SoundEffectInstance** object to the return value of **[SoundEffect.CreateInstance](xref:Microsoft.Xna.Framework.Audio.SoundEffect.CreateInstance)**. We also optionally define a variable **soundFile** to store the location of the sound file being used with the **[TitleContainer.OpenStream](xref:Microsoft.Xna.Framework.TitleContainer#Microsoft_Xna_Framework_TitleContainer_OpenStream_System_String_)** method, which is accessed with the  **using** keyword, and include a field member variable called **soundEffect**, to hold the stream.
 
     ```csharp
     using Stream soundfile = TitleContainer.OpenStream(@"Content\Sound__FileName.wav");
@@ -42,30 +41,31 @@ The **[SoundEffect.Play](xref:Microsoft.Xna.Framework.Audio.SoundEffect.Play)** 
     soundInstance = soundEffect.CreateInstance();
     ```
 
-3. Adjust the sound to the desired level using the [SoundEffectInstance.Pitch](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.Pitch) and [SoundEffectInstance.Volume](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.Volume) properties.
+4. Adjust the sound to the desired level using the [SoundEffectInstance.Pitch](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.Pitch) and [SoundEffectInstance.Volume](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.Volume) properties.
 
     ```csharp
     // Play Sound
     soundEffectInstance.Play();
     ```
 
- > [!NOTE]
- > An instance will play once, to loop the sound, you can use the **[SoundEffectInstance.IsLooped](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.IsLooped)** property to set the sound to loop. Also note that the sound will not repeat until the sound has finished playing. You can utilise the **[SoundEffectInstance.State](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.State)** property to check if the sound is playing, paused or stopped. Use the **[SoundEffectInstance.Stop](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.Stop)** method to stop the sound.
+     > [!NOTE]
+     > An instance will play once, to loop the sound, you can use the **[SoundEffectInstance.IsLooped](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.IsLooped)** property to set the sound to loop. Also note that the sound will not repeat until the sound has finished playing. You can utilise the **[SoundEffectInstance.State](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.State)** property to check if the sound is playing, paused or stopped. Use the **[SoundEffectInstance.Stop](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance.Stop)** method to stop the sound.
 
- ## An Extended Example
+## An Extended Example
 
- 5. Below the **[Game.Draw](xref:Microsoft.Xna.Framework.Game.Draw)** method, create a new method called **IsKeyPressed**, which will check if a specified key is pressed and return a boolean value of true if it has been pressed.
+ 1. Below the **[Game.Draw](xref:Microsoft.Xna.Framework.Game#Microsoft_Xna_Framework_Game_Draw_Microsoft_Xna_Framework_GameTime_)** method, create a new method called **IsKeyPressed**, which will check if a specified key is pressed and return a boolean value of true if it has been pressed.
 
     ```csharp
     private bool IsKeyPressed(Keys key)
     {
         return Keyboard.GetState().IsKeyDown(key);
     }
-	```
 
- 6. In the **[Game.Update](xref:Microsoft.Xna.Framework.Game.Update)** method, check if the **Space** key is pressed and adjust the pitch and volume of the sound effect accordingly. The pitch and volume values are adjusted by +0.1f each time the **Space key** is pressed. The pitch values are clamped to a minimum value of -1.0f and a maximum value of 1.0f, and the volume values are then clamped to a minimum value of 0f and a maximum value of 1.0f. This is done to ensure that the pitch and volume values are within  valid ranges.
+     ```
 
-	```csharp
+ 2. In the **[Game.Update](xref:Microsoft.Xna.Framework.Game#Microsoft_Xna_Framework_Game_Update_Microsoft_Xna_Framework_GameTime_)** method, check if the **Space** key is pressed and adjust the pitch and volume of the sound effect accordingly. The pitch and volume values are adjusted by +0.1f each time the **Space key** is pressed. The pitch values are clamped to a minimum value of -1.0f and a maximum value of 1.0f, and the volume values are then clamped to a minimum value of 0f and a maximum value of 1.0f. This is done to ensure that the pitch and volume values are within  valid ranges.
+
+ ```csharp
     // Check if the SpaceKey is pressed and play the instance
     if (IsKeyPressed(Keys.Space))
         {
@@ -77,7 +77,7 @@ The **[SoundEffect.Play](xref:Microsoft.Xna.Framework.Audio.SoundEffect.Play)** 
          soundEffectInstance.Volume = volume;
          soundEffectInstance.Play();
         }
-	```
+ ```
 
  > [!NOTE]
  > The **MathHelper.Clamp** method is used to ensure that the pitch and volume values are within the valid range. The pitch value is clamped between -1 and 1, while the volume value is clamped between 0 and 1.
@@ -108,9 +108,3 @@ Provides a loaded sound resource.
 [SoundEffectInstance Class](xref:Microsoft.Xna.Framework.Audio.SoundEffectInstance)
 
 Provides a single playing, paused, or stopped instance of a [SoundEffect](xref:Microsoft.Xna.Framework.Audio.SoundEffect) sound.
-
----
-
-© 2012 Microsoft Corporation. All rights reserved.  
-
-© 2024 The MonoGame Foundation.

--- a/articles/monogame/howto/content_pipeline/HowTo_Add_XML.md
+++ b/articles/monogame/howto/content_pipeline/HowTo_Add_XML.md
@@ -4,8 +4,6 @@ description: Describes how to add custom game data as an XML file through the Co
 requireMSLicense: true
 ---
 
-## Adding XML files to game content
-
 Custom game data that is expressed in an XML format can be easily integrated into your game through the MonoGame Content Pipeline.
 
 This example demonstrates the procedure for integrating custom XML data into the content project of a simple game for the Windows platform.
@@ -17,7 +15,7 @@ Within the MonoGame solution, you create a new Windows Game Library project.
 1. Right-click the solution node, point to `Add`, click `New Project`, and then select the `MonoGame Game Library` template.
 
     > [!TIP]
-    > A `MonoGame Game Library` project is created instead of a Content Pipeline Extension Library project so that the class we will define can be used by both the [Content Importer](xref:Microsoft.Xna.Framework.Content.Pipeline.ContentImporter-1) that runs at build-time and the [Content Loader](xref:Microsoft.Xna.Framework.Content.ContentManager#Microsoft_Xna_Framework_Content_ContentManager_Load__1_System_String_) at game runtime.
+    > A `MonoGame Game Library` project is created instead of a Content Pipeline Extension Library project so that the class we will define can be used by both the [Content Importer](https://docs.monogame.net/api/Microsoft.Xna.Framework.Content.Pipeline.ContentImporter-1.html) that runs at build-time and the [Content Loader](xref:Microsoft.Xna.Framework.Content.ContentManager#Microsoft_Xna_Framework_Content_ContentManager_Load__1_System_String_) at game runtime.
 
 2. In the `Name` box, type `MyDataTypes`, and then click `OK`.
 

--- a/articles/monogame/howto/graphics/HowTo_Create_a_RenderTarget.md
+++ b/articles/monogame/howto/graphics/HowTo_Create_a_RenderTarget.md
@@ -13,7 +13,7 @@ The example is very basic but the principles are the same, when drawing to a Ren
 5. Draw your game as normal.
 6. Draw the Render Texture to the screen in the position we desire (e.g. in the lower corner for a mini-map), most likely on top of your game graphics.
 
-> TIP
+> [!TIP]
 > The technique is very useful, especially if you are doing split-screen gaming and need to draw multiple camera views.
 
 ## Requirements

--- a/articles/monogame/howto/graphics/HowTo_RenderModel.md
+++ b/articles/monogame/howto/graphics/HowTo_RenderModel.md
@@ -1,11 +1,10 @@
 ---
 title: How to render a Model using a Basic Effect
-description: Demonstrates how to rotate a group of sprites around a single point.
+description: Demonstrates how to load and render a model using the MonoGame Content Pipeline.
+requireMSLicense: true
 ---
 
-# Rendering a Model with a Basic Effect
-
-Demonstrates how to load and render a model using the MonoGame Content Pipeline. It is assumed that an existing Windows game project is loaded in MonoGame. In this example, the project is called "CPModel."
+> It is assumed that an existing Windows game project is loaded in MonoGame. In this example, the project is called "CPModel."
 
 This example has three main parts: importing and processing the model, drawing the resultant managed object as a model with full lighting effect in the game, and enabling movement of the model with a game pad.
 
@@ -150,11 +149,5 @@ Development is complete so you are ready to build and run the game. Control the 
 
 ## See Also
 
-[Adding Content to a Game](../Content_Pipeline/HowTo_LoadContent.md)
+[Adding Content to a Game](../Content_Pipeline/HowTo_GameContent_Add.md)
 [Using Input](../input/index.md)
-
----
-
-© 2012 Microsoft Corporation. All rights reserved.  
-
-© 2023 The MonoGame Foundation.

--- a/articles/monogame/whatis/content_pipeline/index.md
+++ b/articles/monogame/whatis/content_pipeline/index.md
@@ -1,11 +1,8 @@
 ---
 title: What is the Content pipeline?
-description: The basics of the content pipeline for MonoGame!
+description: The topics in this section describe how to add and load content such as textures, meshes, sounds, and data in your game.
+requireMSLicense: true
 ---
-
-# Adding Content to a Game
-
-The topics in this section describe how to add and load content such as textures, meshes, sounds, and data in your game.
 
 ## In This Section
 
@@ -13,7 +10,7 @@ The topics in this section describe how to add and load content such as textures
 
 Describes the purpose of the MonoGame Content Pipeline and how it helps you add art and data assets to your game.
 
-[Loading Content](../../howto/Content_Pipeline/HowTo_LoadContent.md)
+[Loading Content](../../howto/Content_Pipeline/HowTo_GameContent_Add.md)
 
 Demonstrates how to load content such as models, textures, sounds, and effects.
 
@@ -54,9 +51,3 @@ Describes the valid tags and values for Sprite-Font (.spritefont) XML files used
 [What are the XML Elements for XMLImporter?](CP_XML_Elements.md)
 
 The base elements that are recognized by XmlImporter Class.
-
----
-
-© 2012 Microsoft Corporation. All rights reserved.  
-
-© 2023 The MonoGame Foundation.

--- a/articles/monogame/whatis/index.md
+++ b/articles/monogame/whatis/index.md
@@ -1,11 +1,8 @@
 ---
-title: What is
+title: "What Is" Articles for MonoGame
 description: A series of articles to answer common questions related to MonoGame operation!
+requireMSLicense: true
 ---
-
-# "What Is" Articles for MonoGame
-
-These articles provide a brief introduction into graphics pipeline functionality.
 
 ## In This Section
 
@@ -46,7 +43,5 @@ Presents an overview of the math-related functionality provided by the MonoGame 
 An overview of the MonoGame Class Library reference, containing all the API calls available to the MonoGame Framework.
 
 ---
-
-© 2012 Microsoft Corporation. All rights reserved.  
 
 © 2023 The MonoGame Foundation.


### PR DESCRIPTION
Updated the `HowTo_ChangePitchAndVolume.md` file to enhance readability and clarity of the code and instructions. Changes include bold formatting for method and class names, added explanations for pitch and volume concepts, `using` statements, fields for sound effect and its properties, and modifications to the `Game.LoadContent` method. Also included notes on sound looping, state checking, and usage of `MathHelper.Clamp` method. Extended example added for key press detection and sound effect adjustment. Updated the copyright year to 2024. The subproject commit in MonoGame has been updated to `81ed391a4d0fd81e3ee4bfe2492ad9a0e7f4cfc5`.